### PR TITLE
PubSubSink doc example correction

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/pubsub.md
+++ b/docs/content.zh/docs/connectors/datastream/pubsub.md
@@ -84,7 +84,7 @@ SerializationSchema<SomeObject> serializationSchema = (...);
 SinkFunction<SomeObject> pubsubSink = PubSubSink.newBuilder()
                                                 .withSerializationSchema(serializationSchema)
                                                 .withProjectName("project")
-                                                .withSubscriptionName("subscription")
+                                                .withTopicName("topic")
                                                 .build()
 
 dataStream.addSink(pubsubSink);
@@ -121,7 +121,7 @@ SerializationSchema<SomeObject> serializationSchema = (...);
 SinkFunction<SomeObject> pubsubSink = PubSubSink.newBuilder()
                                                 .withSerializationSchema(serializationSchema)
                                                 .withProjectName("my-fake-project")
-                                                .withSubscriptionName("subscription")
+                                                .withTopicName("topic")
                                                 .withHostAndPortForEmulator(hostAndPort)
                                                 .build();
 

--- a/docs/content/docs/connectors/datastream/pubsub.md
+++ b/docs/content/docs/connectors/datastream/pubsub.md
@@ -90,7 +90,7 @@ SerializationSchema<SomeObject> serializationSchema = (...);
 SinkFunction<SomeObject> pubsubSink = PubSubSink.newBuilder()
                                                 .withSerializationSchema(serializationSchema)
                                                 .withProjectName("project")
-                                                .withSubscriptionName("subscription")
+                                                .withTopicName("topic")
                                                 .build()
 
 dataStream.addSink(pubsubSink);
@@ -123,7 +123,7 @@ SerializationSchema<SomeObject> serializationSchema = (...);
 SinkFunction<SomeObject> pubsubSink = PubSubSink.newBuilder()
                                                 .withSerializationSchema(serializationSchema)
                                                 .withProjectName("my-fake-project")
-                                                .withSubscriptionName("subscription")
+                                                .withTopicName("topic")
                                                 .withHostAndPortForEmulator(hostAndPort)
                                                 .build();
 


### PR DESCRIPTION
The PubSubSink examples should be writing to a topic. 

The correct attribute should be **.withTopicName("topic")** and not the current  **.withSubscriptionName("subscription")**

This is a trivial change that does not require any code changes,  it's a doc update. 

I did the same over here but didn't get any responses - not sure where to correctly update this.

https://github.com/apache/flink/pull/22085