### PR TITLE
[FLINK-31759][pubsub] Using connector_artifact shortcode for datastream document.

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/pubsub.md
+++ b/docs/content.zh/docs/connectors/datastream/pubsub.md
@@ -28,7 +28,7 @@ under the License.
 
 这个连接器可向 [Google Cloud PubSub](https://cloud.google.com/pubsub) 读取与写入数据。添加下面的依赖来使用此连接器:
 
-{{< artifact flink-connector-pubsub >}}
+{{< connector_artifact flink-connector-pubsub 3.0.0 >}}
 
 <p style="border-radius: 5px; padding: 5px" class="bg-danger">
 <b>注意</b>：此连接器最近才加到 Flink 里，还未接受广泛测试。

--- a/docs/content/docs/connectors/datastream/pubsub.md
+++ b/docs/content/docs/connectors/datastream/pubsub.md
@@ -30,7 +30,7 @@ This connector provides a Source and Sink that can read from and write to
 [Google Cloud PubSub](https://cloud.google.com/pubsub). To use this connector, add the
 following dependency to your project:
 
-{{< artifact flink-connector-gcp-pubsub >}}
+{{< connector_artifact flink-connector-gcp-pubsub 3.0.0 >}}
 
 {{< hint warning >}}
 <b>Note</b>: This connector has been added to Flink recently. It has not received widespread testing yet.


### PR DESCRIPTION
This should also backports to v3.0 branch.