### PR TITLE
[FLINK-32031] Flink GCP Connector having issues with Conscrypt library

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -15,6 +15,34 @@
           <option name="issueRegexp" value="#(\d+)" />
           <option name="linkRegexp" value="https://github.com/apache/flink-connector-gcp-pubsub/pull/$1" />
         </IssueNavigationLink>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="\bb/(\d+)(#\w+)?\b" />
+          <option name="linkRegexp" value="https://buganizer.corp.google.com/issues/$1$2" />
+        </IssueNavigationLink>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="\b(?:BUG=|FIXED=)(\d+)\b" />
+          <option name="linkRegexp" value="https://buganizer.corp.google.com/issues/$1" />
+        </IssueNavigationLink>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="\b(?:cl/|cr/|OCL=|DIFFBASE=|ROLLBACK_OF=)(\d+)\b" />
+          <option name="linkRegexp" value="https://critique.corp.google.com/$1" />
+        </IssueNavigationLink>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="\bomg/(\d+)\b" />
+          <option name="linkRegexp" value="https://omg.corp.google.com/$1" />
+        </IssueNavigationLink>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="\b(?:go/|goto/)([^,.&lt;&gt;()&quot;\s]+(?:[.,][^,.&lt;&gt;()&quot;\s]+)*)" />
+          <option name="linkRegexp" value="https://goto.google.com/$1" />
+        </IssueNavigationLink>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="\bcs/([^\s]+[\w$])" />
+          <option name="linkRegexp" value="https://cs.corp.google.com/search/?q=$1" />
+        </IssueNavigationLink>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="(LINT\.IfChange)|(LINT\.ThenChange)" />
+          <option name="linkRegexp" value="https://goto.google.com/ifthisthenthatlint" />
+        </IssueNavigationLink>
       </list>
     </option>
   </component>

--- a/flink-connector-gcp-pubsub-e2e-tests/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/emulator/PubsubHelper.java
+++ b/flink-connector-gcp-pubsub-e2e-tests/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/emulator/PubsubHelper.java
@@ -94,7 +94,7 @@ public class PubsubHelper {
         LOG.info("DeleteTopic {} first delete old subscriptions.", topicName);
         adminClient
                 .listTopicSubscriptions(topicName)
-                .iterateAllAsProjectSubscriptionName()
+                .iterateAll()
                 .forEach(subscriptionAdminClient::deleteSubscription);
         LOG.info("DeleteTopic {}", topicName);
         adminClient.deleteTopic(topicName);

--- a/flink-connector-gcp-pubsub/pom.xml
+++ b/flink-connector-gcp-pubsub/pom.xml
@@ -34,9 +34,9 @@ under the License.
 
 	<packaging>jar</packaging>
 
-	<properties>
-		<google-cloud-libraries-bom.version>8.1.0</google-cloud-libraries-bom.version>
-	</properties>
+<!--	<properties>-->
+<!--		<google-cloud-libraries-bom.version>8.1.0</google-cloud-libraries-bom.version>-->
+<!--	</properties>-->
 
 	<dependencyManagement>
 		<dependencies>

--- a/flink-connector-gcp-pubsub/pom.xml
+++ b/flink-connector-gcp-pubsub/pom.xml
@@ -93,6 +93,93 @@ under the License.
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>io.grpc</groupId>
+			<artifactId>grpc-auth</artifactId>
+			<!-- Version is pulled from google-cloud-bom (loaded via the libraries-bom) -->
+		</dependency>
+
+		<dependency>
+			<groupId>io.grpc</groupId>
+			<artifactId>grpc-netty</artifactId>
+			<!-- Version is pulled from google-cloud-bom (loaded via the libraries-bom) -->
+		</dependency>
+
+		<!-- For dependency convergence -->
+		<dependency>
+			<groupId>com.google.cloud</groupId>
+			<artifactId>google-cloud-core</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>com.google.api</groupId>
+					<artifactId>gax</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.google.guava</groupId>
+					<artifactId>guava</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.google.http-client</groupId>
+					<artifactId>google-http-client</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<!-- For dependency convergence -->
+		<dependency>
+			<groupId>com.google.api</groupId>
+			<artifactId>gax</artifactId>
+			<version>2.18.7</version>
+			<exclusions>
+				<exclusion>
+					<groupId>io.opencensus</groupId>
+					<artifactId>opencensus-api</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<!-- For dependency convergence -->
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>31.1-jre</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.checkerframework</groupId>
+					<artifactId>checker-qual</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<!-- For dependency convergence -->
+		<dependency>
+			<groupId>com.google.http-client</groupId>
+			<artifactId>google-http-client</artifactId>
+			<version>1.42.2</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.httpcomponents</groupId>
+					<artifactId>httpclient</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<!-- For dependency convergence -->
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+			<version>4.5.13</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.httpcomponents</groupId>
+					<artifactId>httpcore</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<dependency>
+			<groupId>io.grpc</groupId>
+			<artifactId>grpc-netty-shaded</artifactId>
+			<!-- Version is pulled from google-cloud-bom (loaded via the libraries-bom) -->
+		</dependency>
 		<!-- ArchUit test dependencies -->
 
 		<dependency>

--- a/flink-connector-gcp-pubsub/pom.xml
+++ b/flink-connector-gcp-pubsub/pom.xml
@@ -33,11 +33,6 @@ under the License.
 	<name>Flink : Connectors : Google PubSub</name>
 
 	<packaging>jar</packaging>
-
-<!--	<properties>-->
-<!--		<google-cloud-libraries-bom.version>8.1.0</google-cloud-libraries-bom.version>-->
-<!--	</properties>-->
-
 	<dependencyManagement>
 		<dependencies>
 			<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,12 @@ under the License.
 	</modules>
 
 	<properties>
+<<<<<<< HEAD
 		<flink.version>1.16.0</flink.version>
+=======
+		<flink.version>1.17.0</flink.version>
+		<google-cloud-libraries-bom.version>26.1.0</google-cloud-libraries-bom.version>
+>>>>>>> 4fdaca7 ([FLINK-32031] Flink GCP Connector having issues with Conscrypt library)
 
 		<junit5.version>5.8.1</junit5.version>
 		<assertj.version>3.23.1</assertj.version>

--- a/pom.xml
+++ b/pom.xml
@@ -48,13 +48,8 @@ under the License.
 	</modules>
 
 	<properties>
-<<<<<<< HEAD
 		<flink.version>1.16.0</flink.version>
-=======
-		<flink.version>1.17.0</flink.version>
 		<google-cloud-libraries-bom.version>26.1.0</google-cloud-libraries-bom.version>
->>>>>>> 4fdaca7 ([FLINK-32031] Flink GCP Connector having issues with Conscrypt library)
-
 		<junit5.version>5.8.1</junit5.version>
 		<assertj.version>3.23.1</assertj.version>
 		<testcontainers.version>1.17.2</testcontainers.version>


### PR DESCRIPTION
# What is the purpose of this change
The Flink GCP Pubsub Connector uses the `gcp-cloud-libraries-bom` which internally uses `conscrypt` library.

This was causing an issue in Dataproc 2.1 image where the Dataproc cluster had more recent version of `conscrypt` library compared to what was available in the connector jar. 

This fix upgrades the `gcp-cloud-libraries-bom` from `8.1.0` to `26.1.0` which removes the `conscrypt` library and few other libraries and updates couple of API changes due to version upgrades

# Brief change log
This fix upgrades the `gcp-cloud-libraries-bom` from `8.1.0` to `26.1.0` which removes the `conscrypt` library and few other libraries and updates couple of API changes due to version upgrades

# Verifying this change
Ran a sample code to read from Google Cloud Pubsub and write to GCS

![image](https://github.com/apache/flink-connector-gcp-pubsub/assets/53975210/72eb5f2a-db7f-43aa-a6b0-0f58f9c57967)
