### PR TITLE
[FLINK-33018][Tests] Fix flaky test when cancelling source

### DIFF
--- a/flink-connector-gcp-pubsub/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/PubSubConsumingTest.java
+++ b/flink-connector-gcp-pubsub/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/PubSubConsumingTest.java
@@ -108,19 +108,19 @@ class PubSubConsumingTest {
         Thread thread = createSourceThread(pubSubSource, lock, results);
         try {
             thread.start();
-            awaitRecordCount(results, 2);
-
-            // we do not emit the end of stream record
-            assertThat(new ArrayList<>(results)).isEqualTo(Arrays.asList("A", "B"));
-            pubSubSource.snapshotState(0, 0);
-            pubSubSource.notifyCheckpointComplete(0);
-            // we acknowledge also the end of the stream record
-            assertThat(testPubSubSubscriber.getAcknowledgedIds())
-                    .isEqualTo(Arrays.asList("1", "2", "3"));
+            // The source thread will finish automatically, without waiting for records or
+            // explicitly cancelling the source.
         } finally {
-            pubSubSource.cancel();
             thread.join();
         }
+
+        // we do not emit the end of stream record
+        assertThat(new ArrayList<>(results)).isEqualTo(Arrays.asList("A", "B"));
+        pubSubSource.snapshotState(0, 0);
+        pubSubSource.notifyCheckpointComplete(0);
+        // we acknowledge also the end of the stream record
+        assertThat(testPubSubSubscriber.getAcknowledgedIds())
+                .isEqualTo(Arrays.asList("1", "2", "3"));
     }
 
     @Test


### PR DESCRIPTION
We sometimes observe the test failure described in FLINK-33018

```
Expected :["1", "2", "3"]
Actual   :["1", "2"]
```

This occurs because the thread running the source is explicitly cancelled in the **finally** clause.  Unlike the other tests in this class, the source thread should run to completion and finish when the last message ID (`"3"`) arrives without external intervention.

In rare cases, it was possible for the explicit `cancel()` to happen after the two records arrived, but before the third record causes the source to cleanly shut itself down and finish.

This is fixed by no longer waiting for any records to arrive, just letting the thread run to completion, and _then_ testing the results.

I checked this by running this particular test as a `@RepeatedTest(100_000)`.  I have never observed the behaviour described in the issue after this change, but I've noticed that *with or without* the change, this test will consistently fail after the 16,248-16,250th execution, during the `thread.start()`.