### PR TITLE
[hotfix][build] Bump lowest supported flink version to 1.17.0

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -25,4 +25,4 @@ jobs:
   compile_and_test:
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:
-      flink_version: 1.16.1
+      flink_version: 1.17.1

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -26,7 +26,7 @@ jobs:
     if: github.repository_owner == 'apache'
     strategy:
       matrix:
-        flink: [1.16-SNAPSHOT, 1.17-SNAPSHOT]
+        flink: [1.17.1, 1.18.0]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:
       flink_version: ${{ matrix.flink }}

--- a/pom.xml
+++ b/pom.xml
@@ -296,7 +296,14 @@ under the License.
 			<dependency>
 				<groupId>org.junit.platform</groupId>
 				<artifactId>junit-platform-engine</artifactId>
-				<version>1.8.1</version>
+				<version>1.9.1</version>
+			</dependency>
+
+			<!-- For dependency convergence -->
+			<dependency>
+				<groupId>org.junit.platform</groupId>
+				<artifactId>junit-platform-commons</artifactId>
+				<version>1.9.1</version>
 			</dependency>
 
 			<!-- For dependency convergence -->

--- a/pom.xml
+++ b/pom.xml
@@ -48,12 +48,12 @@ under the License.
 	</modules>
 
 	<properties>
-		<flink.version>1.16.0</flink.version>
+		<flink.version>1.17.0</flink.version>
 		<google-cloud-libraries-bom.version>26.1.0</google-cloud-libraries-bom.version>
-		<junit5.version>5.8.1</junit5.version>
+		<junit5.version>5.9.1</junit5.version>
 		<assertj.version>3.23.1</assertj.version>
 		<testcontainers.version>1.17.2</testcontainers.version>
-		<mockito.version>2.21.0</mockito.version>
+		<mockito.version>3.4.6</mockito.version>
 		<hamcrest.version>1.3</hamcrest.version>
 
 		<japicmp.skip>false</japicmp.skip>


### PR DESCRIPTION
Bump lowest supported flink version to 1.17.0 as the discussion thread[1]

[1] https://lists.apache.org/thread/2qqd59nng50k4po1dlyoxkwjmvb2fmb4