### PR TITLE
[hotfix] Drop support for Flink1.16, add support for Flink 1.19, 1.20

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -25,7 +25,7 @@ jobs:
   compile_and_test:
     strategy:
       matrix:
-        flink: [1.16-SNAPSHOT, 1.17-SNAPSHOT, 1.18-SNAPSHOT]
+        flink: [1.17-SNAPSHOT, 1.18-SNAPSHOT, 1.19-SNAPSHOT, 1.20-SNAPSHOT]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:
       flink_version: ${{ matrix.flink }}

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -16,7 +16,10 @@
 # limitations under the License.
 ################################################################################
 
-name: CI
+# We need to specify repo related information here since Apache INFRA doesn't differentiate
+# between several workflows with the same names while preparing a report for GHA usage
+# https://infra-reports.apache.org/#ghactions
+name: Flink Connector GCP PubSub CI
 on: [push, pull_request]
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -25,7 +28,16 @@ jobs:
   compile_and_test:
     strategy:
       matrix:
-        flink: [1.17-SNAPSHOT, 1.18-SNAPSHOT, 1.19-SNAPSHOT, 1.20-SNAPSHOT]
+          flink: [ 1.17-SNAPSHOT ]
+          jdk: [ '8, 11' ]
+          include:
+            - flink: 1.18-SNAPSHOT
+              jdk: '8, 11, 17'
+            - flink: 1.19-SNAPSHOT
+              jdk: '8, 11, 17, 21'
+            - flink: 1.20-SNAPSHOT
+              jdk: '8, 11, 17, 21'
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:
       flink_version: ${{ matrix.flink }}
+      jdk_version: ${{ matrix.jdk }}

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -27,7 +27,10 @@ jobs:
     strategy:
       matrix:
         flink_branches: [{
-          flink: 1.16-SNAPSHOT,
+          flink: 1.20-SNAPSHOT,
+          branch: main
+        }, {
+          flink: 1.19-SNAPSHOT,
           branch: main
         }, {
           flink: 1.17-SNAPSHOT,
@@ -36,13 +39,13 @@ jobs:
           flink: 1.18-SNAPSHOT,
           branch: main
         }, {
-          flink: 1.16.2,
+          flink: 1.19.0,
           branch: v3.0
         }, {
-          flink: 1.17.1,
+          flink: 1.18.1,
           branch: v3.0
         }, {
-          flink: 1.18-SNAPSHOT,
+          flink: 1.17.2,
           branch: v3.0
         }]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -16,7 +16,10 @@
 # limitations under the License.
 ################################################################################
 
-name: Nightly
+# We need to specify repo related information here since Apache INFRA doesn't differentiate
+# between several workflows with the same names while preparing a report for GHA usage
+# https://infra-reports.apache.org/#ghactions
+name: Weekly Flink Connector GCP PubSub
 on:
   schedule:
     - cron: "0 0 * * 0"
@@ -28,21 +31,26 @@ jobs:
       matrix:
         flink_branches: [{
           flink: 1.20-SNAPSHOT,
+          jdk: '8, 11, 17, 21',
           branch: main
         }, {
           flink: 1.19-SNAPSHOT,
+          jdk: '8, 11, 17, 21',
           branch: main
         }, {
           flink: 1.17-SNAPSHOT,
           branch: main
         }, {
           flink: 1.18-SNAPSHOT,
+          jdk: '8, 11, 17',
           branch: main
         }, {
           flink: 1.19.0,
+          jdk: '8, 11, 17, 21',
           branch: v3.0
         }, {
           flink: 1.18.1,
+          jdk: '8, 11, 17',
           branch: v3.0
         }, {
           flink: 1.17.2,
@@ -51,5 +59,6 @@ jobs:
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils
     with:
       flink_version: ${{ matrix.flink_branches.flink }}
+      jdk_version: ${{ matrix.flink_branches.jdk || '8, 11' }}
       connector_branch: ${{ matrix.flink_branches.branch }}
       run_dependency_convergence: false

--- a/flink-connector-gcp-pubsub/pom.xml
+++ b/flink-connector-gcp-pubsub/pom.xml
@@ -86,6 +86,13 @@ under the License.
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-netty</artifactId>
 			<!-- Version is pulled from google-cloud-bom (loaded via the libraries-bom) -->
+			<exclusions>
+				<!-- Since with google-cloud-bom there comes a newer version -->
+				<exclusion>
+					<groupId>io.perfmark</groupId>
+					<artifactId>perfmark-api</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<!-- For dependency convergence -->
@@ -105,13 +112,17 @@ under the License.
 					<groupId>com.google.http-client</groupId>
 					<artifactId>google-http-client</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>com.google.j2objc</groupId>
+					<artifactId>j2objc-annotations</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<!-- For dependency convergence -->
 		<dependency>
 			<groupId>com.google.api</groupId>
 			<artifactId>gax</artifactId>
-			<version>2.18.7</version>
+			<version>2.46.1</version>
 			<exclusions>
 				<exclusion>
 					<groupId>io.opencensus</groupId>
@@ -123,7 +134,7 @@ under the License.
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>31.1-jre</version>
+			<version>33.1.0-jre</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.checkerframework</groupId>
@@ -134,13 +145,24 @@ under the License.
 
 		<!-- For dependency convergence -->
 		<dependency>
+			<groupId>com.google.j2objc</groupId>
+			<artifactId>j2objc-annotations</artifactId>
+			<version>3.0.0</version>
+		</dependency>
+
+		<!-- For dependency convergence -->
+		<dependency>
 			<groupId>com.google.http-client</groupId>
 			<artifactId>google-http-client</artifactId>
-			<version>1.42.2</version>
+			<version>1.44.1</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.apache.httpcomponents</groupId>
 					<artifactId>httpclient</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.google.j2objc</groupId>
+					<artifactId>j2objc-annotations</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>
@@ -149,7 +171,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.5.13</version>
+			<version>4.5.14</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.apache.httpcomponents</groupId>
@@ -162,6 +184,13 @@ under the License.
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-netty-shaded</artifactId>
 			<!-- Version is pulled from google-cloud-bom (loaded via the libraries-bom) -->
+			<exclusions>
+				<!-- Since with google-cloud-bom there comes a newer version -->
+				<exclusion>
+					<groupId>io.perfmark</groupId>
+					<artifactId>perfmark-api</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<!-- ArchUit test dependencies -->
 

--- a/flink-connector-gcp-pubsub/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/PubSubSourceTest.java
+++ b/flink-connector-gcp-pubsub/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/PubSubSourceTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.connectors.gcp.pubsub;
 import org.apache.flink.api.common.io.ratelimiting.FlinkConnectorRateLimiter;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.groups.OperatorMetricGroup;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
@@ -91,7 +92,7 @@ class PubSubSourceTest {
     @Test
     void testOpenWithoutCheckpointing() {
         when(streamingRuntimeContext.isCheckpointingEnabled()).thenReturn(false);
-        assertThatThrownBy(() -> pubSubSource.open(null))
+        assertThatThrownBy(() -> pubSubSource.open((Configuration) null))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -99,7 +100,7 @@ class PubSubSourceTest {
     void testOpenWithCheckpointing() throws Exception {
         when(streamingRuntimeContext.isCheckpointingEnabled()).thenReturn(true);
 
-        pubSubSource.open(null);
+        pubSubSource.open((Configuration) null);
 
         verify(pubSubSubscriberFactory, times(1)).getSubscriber(eq(credentials));
         verify(acknowledgeOnCheckpointFactory, times(1)).create(pubsubSubscriber);
@@ -118,7 +119,7 @@ class PubSubSourceTest {
 
     @Test
     void testNotifyCheckpointComplete() throws Exception {
-        pubSubSource.open(null);
+        pubSubSource.open((Configuration) null);
         pubSubSource.notifyCheckpointComplete(45L);
 
         verify(acknowledgeOnCheckpoint, times(1)).notifyCheckpointComplete(45L);
@@ -126,7 +127,7 @@ class PubSubSourceTest {
 
     @Test
     void testRestoreState() throws Exception {
-        pubSubSource.open(null);
+        pubSubSource.open((Configuration) null);
 
         List<AcknowledgeIdsForCheckpoint<String>> input = new ArrayList<>();
         pubSubSource.restoreState(input);
@@ -136,7 +137,7 @@ class PubSubSourceTest {
 
     @Test
     void testSnapshotState() throws Exception {
-        pubSubSource.open(null);
+        pubSubSource.open((Configuration) null);
         pubSubSource.snapshotState(1337L, 15000L);
 
         verify(acknowledgeOnCheckpoint, times(1)).snapshotState(1337L, 15000L);
@@ -153,7 +154,7 @@ class PubSubSourceTest {
                         })
                 .when(deserializationSchema)
                 .open(any(DeserializationSchema.InitializationContext.class));
-        pubSubSource.open(null);
+        pubSubSource.open((Configuration) null);
 
         verify(deserializationSchema, times(1))
                 .open(any(DeserializationSchema.InitializationContext.class));

--- a/pom.xml
+++ b/pom.xml
@@ -50,19 +50,19 @@ under the License.
 
 	<properties>
 		<flink.version>1.17.0</flink.version>
-		<google-cloud-libraries-bom.version>26.1.0</google-cloud-libraries-bom.version>
+		<google-cloud-libraries-bom.version>26.37.0</google-cloud-libraries-bom.version>
 
-		<junit5.version>5.9.1</junit5.version>
-		<assertj.version>3.23.1</assertj.version>
-		<testcontainers.version>1.17.2</testcontainers.version>
-		<mockito.version>3.4.6</mockito.version>
-		<hamcrest.version>1.3</hamcrest.version>
+		<junit5.version>5.10.2</junit5.version>
+		<assertj.version>3.25.3</assertj.version>
+		<testcontainers.version>1.19.7</testcontainers.version>
+		<mockito.version>3.12.4</mockito.version>
+		<hamcrest.version>2.2</hamcrest.version>
 
 		<japicmp.skip>false</japicmp.skip>
 		<japicmp.referenceVersion>3.0.0-1.16.0</japicmp.referenceVersion>
 
 		<slf4j.version>1.7.36</slf4j.version>
-		<log4j.version>2.17.2</log4j.version>
+		<log4j.version>2.23.1</log4j.version>
 
 		<flink.parent.artifactId>flink-connector-gcp-pubsub-parent</flink.parent.artifactId>
 	</properties>
@@ -161,9 +161,8 @@ under the License.
 
 		<dependency>
 			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-all</artifactId>
+			<artifactId>hamcrest</artifactId>
 			<version>${hamcrest.version}</version>
-			<type>jar</type>
 			<scope>test</scope>
 		</dependency>
 
@@ -256,7 +255,35 @@ under the License.
 			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-lang3</artifactId>
-				<version>3.5</version>
+				<version>3.14.0</version>
+			</dependency>
+
+			<!-- For dependency convergence -->
+			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-compress</artifactId>
+				<version>1.26.1</version>
+			</dependency>
+
+			<!-- For dependency convergence -->
+			<dependency>
+				<groupId>commons-io</groupId>
+				<artifactId>commons-io</artifactId>
+				<version>2.15.1</version>
+			</dependency>
+
+			<!-- For dependency convergence -->
+			<dependency>
+				<groupId>org.assertj</groupId>
+				<artifactId>assertj-core</artifactId>
+				<version>${assertj.version}</version>
+			</dependency>
+
+			<!-- Test dependencies -->
+			<dependency>
+				<groupId>org.junit.jupiter</groupId>
+				<artifactId>junit-jupiter</artifactId>
+				<version>${junit5.version}</version>
 			</dependency>
 
 			<!-- For dependency convergence -->
@@ -270,14 +297,14 @@ under the License.
 			<dependency>
 				<groupId>com.google.errorprone</groupId>
 				<artifactId>error_prone_annotations</artifactId>
-				<version>2.4.0</version>
+				<version>2.26.1</version>
 			</dependency>
 
 			<!-- For dependency convergence -->
 			<dependency>
 				<groupId>net.bytebuddy</groupId>
 				<artifactId>byte-buddy</artifactId>
-				<version>1.12.10</version>
+				<version>1.14.13</version>
 			</dependency>
 
 			<!-- For dependency convergence -->
@@ -298,14 +325,14 @@ under the License.
 			<dependency>
 				<groupId>org.junit.platform</groupId>
 				<artifactId>junit-platform-engine</artifactId>
-				<version>1.9.1</version>
+				<version>1.10.2</version>
 			</dependency>
 
 			<!-- For dependency convergence -->
 			<dependency>
 				<groupId>org.junit.platform</groupId>
 				<artifactId>junit-platform-commons</artifactId>
-				<version>1.9.1</version>
+				<version>1.10.2</version>
 			</dependency>
 
 			<!-- For dependency convergence -->


### PR DESCRIPTION
The PR drops support for Flink 1.16, adds support for 1.19, 1.20
also it adds jdk 17 and 21 to the ci
updates dependencies and renames ci