### PR TITLE
[FLINK-35135][Connectors/Google Cloud PubSub] Drop support for Flink 1.17

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -28,11 +28,9 @@ jobs:
   compile_and_test:
     strategy:
       matrix:
-          flink: [ 1.17-SNAPSHOT ]
-          jdk: [ '8, 11' ]
+          flink: [ 1.18-SNAPSHOT ]
+          jdk: [ '8, 11, 17' ]
           include:
-            - flink: 1.18-SNAPSHOT
-              jdk: '8, 11, 17'
             - flink: 1.19-SNAPSHOT
               jdk: '8, 11, 17, 21'
             - flink: 1.20-SNAPSHOT

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -38,9 +38,6 @@ jobs:
           jdk: '8, 11, 17, 21',
           branch: main
         }, {
-          flink: 1.17-SNAPSHOT,
-          branch: main
-        }, {
           flink: 1.18-SNAPSHOT,
           jdk: '8, 11, 17',
           branch: main
@@ -51,9 +48,6 @@ jobs:
         }, {
           flink: 1.18.1,
           jdk: '8, 11, 17',
-          branch: v3.0
-        }, {
-          flink: 1.17.2,
           branch: v3.0
         }]
     uses: apache/flink-connector-shared-utils/.github/workflows/ci.yml@ci_utils

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@ under the License.
 	</modules>
 
 	<properties>
-		<flink.version>1.17.0</flink.version>
+		<flink.version>1.18.0</flink.version>
 		<google-cloud-libraries-bom.version>26.37.0</google-cloud-libraries-bom.version>
 
 		<junit5.version>5.10.2</junit5.version>


### PR DESCRIPTION
Drop 1.17 runs from CI and bump default Flink version in pom 