### PR TITLE
[FLINK-35322][Connectors/Google PubSub] Remove weekly tests of 1.19 for unsupporting version v3.0

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -42,10 +42,6 @@ jobs:
           jdk: '8, 11, 17',
           branch: main
         }, {
-          flink: 1.19.0,
-          jdk: '8, 11, 17, 21',
-          branch: v3.0
-        }, {
           flink: 1.18.1,
           jdk: '8, 11, 17',
           branch: v3.0


### PR DESCRIPTION
## Description

- Weekly builds are failing due to tests against Flink 1.19 using version 3.0 which is incompatible.
- We should only add stable release tests on 3.1 once released

## Changelog
- Remove weekly tests for 1.19 using v3.0, leaving only main branch.

## Testing

- Run weekly on fork: https://github.com/vahmed-hamdy/flink-connector-gcp-pubsub/actions/runs/9050181335/job/24865230544
