### PR TITLE
[FLINK-36077][Connectors/Google PubSub] Implement table api support for SinkV2

### DIFF
--- a/flink-connector-gcp-pubsub/pom.xml
+++ b/flink-connector-gcp-pubsub/pom.xml
@@ -57,6 +57,12 @@ under the License.
 		</dependency>
 
 		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-common</artifactId>
+			<version>${flink.version}</version>
+		</dependency>
+
+		<dependency>
 			<groupId>com.google.cloud</groupId>
 			<artifactId>google-cloud-core</artifactId>
 			<!-- Version is pulled from google-cloud-bom (loaded via the libraries-bom) -->
@@ -77,6 +83,21 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-streaming-java</artifactId>
+			<version>${flink.version}</version>
+			<scope>test</scope>
+			<type>test-jar</type>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-runtime</artifactId>
+			<version>${flink.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-common</artifactId>
 			<version>${flink.version}</version>
 			<scope>test</scope>
 			<type>test-jar</type>

--- a/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/connector/gcp/pubsub/sink/config/GcpPublisherConfig.java
+++ b/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/connector/gcp/pubsub/sink/config/GcpPublisherConfig.java
@@ -9,6 +9,7 @@ import com.google.api.gax.retrying.RetrySettings;
 import com.google.api.gax.rpc.TransportChannelProvider;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 /** Configuration keys for {@link com.google.cloud.pubsub.v1.Publisher}. */
 @PublicEvolving
@@ -56,6 +57,50 @@ public class GcpPublisherConfig implements Serializable {
             return null;
         }
         return transportChannelProvider.getTransportChannelProvider();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        GcpPublisherConfig that = (GcpPublisherConfig) o;
+
+        return Objects.equals(retrySettings, that.retrySettings)
+                && Objects.equals(batchingSettings, that.batchingSettings)
+                && Objects.equals(credentialsProvider, that.credentialsProvider)
+                && Objects.equals(transportChannelProvider, that.transportChannelProvider)
+                && Objects.equals(enableCompression, that.enableCompression);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                retrySettings,
+                batchingSettings,
+                credentialsProvider,
+                transportChannelProvider,
+                enableCompression);
+    }
+
+    @Override
+    public String toString() {
+        return "GcpPublisherConfig{"
+                + "retrySettings="
+                + retrySettings
+                + ", batchingSettings="
+                + batchingSettings
+                + ", credentialsProvider="
+                + credentialsProvider
+                + ", transportChannelProvider="
+                + transportChannelProvider
+                + ", enableCompression="
+                + enableCompression
+                + '}';
     }
 
     public Boolean getEnableCompression() {

--- a/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/connector/gcp/pubsub/sink/config/SerializableTransportChannelProvider.java
+++ b/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/connector/gcp/pubsub/sink/config/SerializableTransportChannelProvider.java
@@ -5,6 +5,7 @@ import org.apache.flink.annotation.PublicEvolving;
 import com.google.api.gax.rpc.TransportChannelProvider;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * A serializable transport channel provider for {@link
@@ -23,5 +24,24 @@ public abstract class SerializableTransportChannelProvider implements Serializab
             open();
         }
         return transportChannelProvider;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        SerializableTransportChannelProvider that = (SerializableTransportChannelProvider) o;
+
+        return Objects.equals(transportChannelProvider, that.transportChannelProvider);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(transportChannelProvider);
     }
 }

--- a/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/connector/gcp/pubsub/table/CredentialProviderFactory.java
+++ b/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/connector/gcp/pubsub/table/CredentialProviderFactory.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.gcp.pubsub.table;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.StringUtils;
+
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.GoogleCredentials;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.cloud.pubsub.v1.SubscriptionAdminSettings.defaultCredentialsProviderBuilder;
+import static org.apache.flink.connector.gcp.pubsub.table.PubSubOptions.CREDENTIALS_FIXED_ACCESS_EXPIRATION_EPOCH_MILLIS;
+import static org.apache.flink.connector.gcp.pubsub.table.PubSubOptions.CREDENTIALS_FIXED_ACCESS_TOKEN;
+import static org.apache.flink.connector.gcp.pubsub.table.PubSubOptions.CREDENTIALS_FIXED_JSON;
+
+/**
+ * Factory for creating {@link com.google.api.gax.core.CredentialsProvider} from PubSub Table
+ * Options.
+ */
+@Internal
+class CredentialProviderFactory {
+    private static final String PUBSUB_AUTH_SCOPES = "https://www.googleapis.com/auth/pubsub";
+    private static final String PUBSUB_AUTH_CLOUD_PLATFORM_SCOPES =
+            "https://www.googleapis.com/auth/cloud-platform";
+    private static final String CREDENTIALS_PROVIDER_PREFIX = "credentials-provider.";
+
+    public CredentialsProvider createCredentialsProvider(
+            CredentialProviderType credentialType, Map<String, String> options) {
+        switch (credentialType) {
+            case DEFAULT:
+            case GOOGLE_CREDENTIALS:
+                return defaultCredentialsProviderBuilder().build();
+            case FIXED:
+                return FixedCredentialsProvider.create(getFixedCredentialsFromOptions(options));
+            default:
+                throw new IllegalArgumentException(
+                        "Unknown credential provider type: " + credentialType);
+        }
+    }
+
+    private GoogleCredentials getFixedCredentialsFromOptions(Map<String, String> options) {
+        Preconditions.checkArgument(
+                options != null
+                        && (extractCredentialProviderOption(options, CREDENTIALS_FIXED_JSON) != null
+                                || extractCredentialProviderOption(
+                                                options, CREDENTIALS_FIXED_ACCESS_TOKEN)
+                                        != null),
+                "Fixed credential provider requires '"
+                        + CREDENTIALS_FIXED_JSON.key()
+                        + "' or '"
+                        + CREDENTIALS_FIXED_ACCESS_TOKEN.key()
+                        + "' options to be set");
+
+        Optional<GoogleCredentials> jsonCredsOptional =
+                Optional.ofNullable(
+                                extractCredentialProviderOption(options, CREDENTIALS_FIXED_JSON))
+                        .map(this::getJsonCredentials);
+        Optional<GoogleCredentials> accessTokenCredsOptional =
+                Optional.ofNullable(
+                                extractCredentialProviderOption(
+                                        options, CREDENTIALS_FIXED_ACCESS_TOKEN))
+                        .map(
+                                accessToken ->
+                                        getAccessTokenCredentials(
+                                                accessToken,
+                                                extractCredentialProviderOption(
+                                                        options,
+                                                        CREDENTIALS_FIXED_ACCESS_EXPIRATION_EPOCH_MILLIS)));
+
+        if (!jsonCredsOptional.isPresent() && !accessTokenCredsOptional.isPresent()) {
+            throw new IllegalArgumentException(
+                    "Fixed credential provider requires '"
+                            + CREDENTIALS_FIXED_JSON.key()
+                            + "' or '"
+                            + CREDENTIALS_FIXED_ACCESS_TOKEN.key()
+                            + "' options to be set");
+        }
+
+        return jsonCredsOptional.orElseGet(accessTokenCredsOptional::get);
+    }
+
+    private String extractCredentialProviderOption(
+            Map<String, String> options, ConfigOption<?> option) {
+        Preconditions.checkNotNull(options);
+        Preconditions.checkArgument(option.key().startsWith(CREDENTIALS_PROVIDER_PREFIX));
+        return options.get(option.key().substring(CREDENTIALS_PROVIDER_PREFIX.length()));
+    }
+
+    private GoogleCredentials getJsonCredentials(String credentialsStringJson) {
+        Preconditions.checkArgument(!StringUtils.isNullOrWhitespaceOnly(credentialsStringJson));
+
+        try {
+            return GoogleCredentials.fromStream(
+                    new ByteArrayInputStream(credentialsStringJson.getBytes()));
+        } catch (IOException e) {
+            throw new IllegalArgumentException(
+                    "Failed to load Google Credentials from file " + credentialsStringJson, e);
+        }
+    }
+
+    private GoogleCredentials getAccessTokenCredentials(
+            String credentialsAccessToken, String credentialsAccessExpirationEpochMillis) {
+
+        Preconditions.checkArgument(
+                !StringUtils.isNullOrWhitespaceOnly(credentialsAccessToken),
+                "Fixed credential provider requires '"
+                        + CREDENTIALS_FIXED_JSON.key()
+                        + "' or '"
+                        + CREDENTIALS_FIXED_ACCESS_TOKEN.key()
+                        + "' options to be set");
+        Long expirationEpochMillis;
+
+        try {
+            expirationEpochMillis =
+                    StringUtils.isNullOrWhitespaceOnly(credentialsAccessExpirationEpochMillis)
+                            ? null
+                            : Long.parseLong(credentialsAccessExpirationEpochMillis);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(
+                    "Failed to parse expiration epoch millis: "
+                            + credentialsAccessExpirationEpochMillis,
+                    e);
+        }
+
+        return GoogleCredentials.create(
+                getAccessTokenFromOptions(credentialsAccessToken, expirationEpochMillis));
+    }
+
+    private AccessToken getAccessTokenFromOptions(
+            String credentialsAccessToken, Long credentialsAccessExpirationEpochMillis) {
+        AccessToken.Builder builder =
+                AccessToken.newBuilder()
+                        .setTokenValue(credentialsAccessToken)
+                        .setScopes(
+                                Arrays.asList(
+                                        PUBSUB_AUTH_CLOUD_PLATFORM_SCOPES, PUBSUB_AUTH_SCOPES));
+        if (credentialsAccessExpirationEpochMillis != null) {
+            builder.setExpirationTime(
+                    Date.from(Instant.ofEpochMilli(credentialsAccessExpirationEpochMillis)));
+        }
+
+        return builder.build();
+    }
+}

--- a/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/connector/gcp/pubsub/table/CredentialProviderType.java
+++ b/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/connector/gcp/pubsub/table/CredentialProviderType.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.gcp.pubsub.table;
+
+import org.apache.flink.annotation.Internal;
+
+/** GCP Credential provider type. */
+@Internal
+public enum CredentialProviderType {
+
+    /** Default Google Credential Providers. */
+    DEFAULT("default"),
+
+    /** {@link com.google.api.gax.core.FixedCredentialsProvider} with the provided credentials. */
+    FIXED("fixed"),
+
+    /** {@link com.google.api.gax.core.GoogleCredentialsProvider} with default credentials. */
+    GOOGLE_CREDENTIALS("google-credentials");
+
+    private final String type;
+
+    CredentialProviderType(String type) {
+        this.type = type;
+    }
+
+    @Override
+    public String toString() {
+        return type;
+    }
+}

--- a/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/connector/gcp/pubsub/table/PubSubDynamicSink.java
+++ b/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/connector/gcp/pubsub/table/PubSubDynamicSink.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.gcp.pubsub.table;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.connector.gcp.pubsub.sink.PubSubSinkV2Builder;
+import org.apache.flink.connector.gcp.pubsub.sink.config.GcpPublisherConfig;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.format.EncodingFormat;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.sink.SinkV2Provider;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.DataType;
+
+import javax.annotation.Nullable;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * PubSub implementation of {@link DynamicTableSink} that provides {@link
+ * org.apache.flink.connector.gcp.pubsub.sink.PubSubSinkV2}.
+ */
+@Internal
+class PubSubDynamicSink implements DynamicTableSink {
+
+    /** Data type that describes the final output of the source. */
+    private final DataType consumedDataType;
+
+    /** Google Cloud project id. */
+    private final String projectId;
+
+    /** Google Cloud Pub/Sub topic id for the table. */
+    private final String topic;
+
+    /** Google Cloud Publisher configuration. */
+    private final GcpPublisherConfig gcpPublisherConfig;
+
+    /** Format for encoding values to pubsub. */
+    private final EncodingFormat<SerializationSchema<RowData>> encodingFormat;
+
+    /** Maximum number of in-flight requests handled by sink. */
+    private final Integer numMaxInflightRequests;
+
+    /** Flag to determine if the sink should fail on errors. */
+    private final Boolean failOnError;
+
+    public PubSubDynamicSink(
+            DataType consumedDataType,
+            String projectId,
+            String topic,
+            GcpPublisherConfig gcpPublisherConfig,
+            EncodingFormat<SerializationSchema<RowData>> encodingFormat,
+            @Nullable Integer numMaxInflightRequests,
+            @Nullable Boolean failOnError) {
+        this.consumedDataType = consumedDataType;
+        this.projectId = projectId;
+        this.topic = topic;
+        this.gcpPublisherConfig = gcpPublisherConfig;
+        this.encodingFormat = encodingFormat;
+        this.numMaxInflightRequests = numMaxInflightRequests;
+        this.failOnError = failOnError;
+    }
+
+    @Override
+    public ChangelogMode getChangelogMode(ChangelogMode changelogMode) {
+        // the PubSub sink only supports insert-only mode
+        return ChangelogMode.insertOnly();
+    }
+
+    @Override
+    public SinkRuntimeProvider getSinkRuntimeProvider(Context context) {
+        PubSubSinkV2Builder<RowData> builder =
+                new PubSubSinkV2Builder<RowData>()
+                        .setSerializationSchema(
+                                encodingFormat.createRuntimeEncoder(context, consumedDataType))
+                        .setProjectId(projectId)
+                        .setTopicId(topic)
+                        .setGcpPublisherConfig(gcpPublisherConfig);
+        Optional.ofNullable(numMaxInflightRequests).ifPresent(builder::setNumMaxInflightRequests);
+        Optional.ofNullable(failOnError).ifPresent(builder::setFailOnError);
+
+        return SinkV2Provider.of(builder.build());
+    }
+
+    @Override
+    public DynamicTableSink copy() {
+        return new PubSubDynamicSink(
+                consumedDataType,
+                projectId,
+                topic,
+                gcpPublisherConfig,
+                encodingFormat,
+                numMaxInflightRequests,
+                failOnError);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        PubSubDynamicSink that = (PubSubDynamicSink) o;
+
+        return Objects.equals(projectId, that.projectId)
+                && Objects.equals(topic, that.topic)
+                && Objects.equals(gcpPublisherConfig, that.gcpPublisherConfig)
+                && Objects.equals(encodingFormat, that.encodingFormat)
+                && Objects.equals(numMaxInflightRequests, that.numMaxInflightRequests)
+                && Objects.equals(failOnError, that.failOnError);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                projectId,
+                topic,
+                gcpPublisherConfig,
+                encodingFormat,
+                numMaxInflightRequests,
+                failOnError);
+    }
+
+    @Override
+    public String toString() {
+        return asSummaryString();
+    }
+
+    @Override
+    public String asSummaryString() {
+        return "PubSubDynamicSink{"
+                + "projectId='"
+                + projectId
+                + '\''
+                + ", topic='"
+                + topic
+                + '\''
+                + ", numMaxInflightRequests="
+                + numMaxInflightRequests
+                + ", config="
+                + gcpPublisherConfig.toString()
+                + ", failOnError="
+                + failOnError
+                + '}';
+    }
+}

--- a/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/connector/gcp/pubsub/table/PubSubDynamicSinkFactory.java
+++ b/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/connector/gcp/pubsub/table/PubSubDynamicSinkFactory.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.gcp.pubsub.table;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.connector.gcp.pubsub.sink.config.GcpPublisherConfig;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
+import org.apache.flink.table.connector.format.EncodingFormat;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.factories.DynamicTableSinkFactory;
+import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.factories.SerializationFormatFactory;
+
+import com.google.api.gax.batching.BatchingSettings;
+import com.google.api.gax.batching.FlowControlSettings;
+import com.google.api.gax.retrying.RetrySettings;
+import org.threeten.bp.Duration;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.apache.flink.connector.gcp.pubsub.table.PubSubOptions.CREDENTIALS_PROVIDER;
+import static org.apache.flink.table.factories.FactoryUtil.FORMAT;
+
+/** Factory for creating {@link PubSubDynamicSink}. */
+@Internal
+public class PubSubDynamicSinkFactory implements DynamicTableSinkFactory {
+    public static final String IDENTIFIER = "pubsub";
+
+    @Override
+    public DynamicTableSink createDynamicTableSink(Context context) {
+        ResolvedCatalogTable catalogTable = context.getCatalogTable();
+        FactoryUtil.TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
+        EncodingFormat<SerializationSchema<RowData>> format =
+                helper.discoverEncodingFormat(SerializationFormatFactory.class, FORMAT);
+        helper.validate();
+        ReadableConfig config = helper.getOptions();
+        return new PubSubDynamicSink(
+                catalogTable.getResolvedSchema().toPhysicalRowDataType(),
+                config.get(PubSubOptions.PROJECT),
+                config.get(PubSubOptions.TOPIC),
+                getResolvedPublisherConfig(config),
+                format,
+                config.get(PubSubOptions.MAX_IN_FLIGHT_REQUESTS),
+                config.get(PubSubOptions.FAIL_ON_ERROR));
+    }
+
+    @Override
+    public String factoryIdentifier() {
+        return IDENTIFIER;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> requiredOptions() {
+        final Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(PubSubOptions.PROJECT);
+        options.add(PubSubOptions.TOPIC);
+        options.add(FORMAT);
+        return options;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> optionalOptions() {
+        final Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(PubSubOptions.CREDENTIALS_PROVIDER_TYPE);
+        options.add(PubSubOptions.CREDENTIALS_FIXED_JSON);
+        options.add(PubSubOptions.CREDENTIALS_FIXED_ACCESS_TOKEN);
+        options.add(PubSubOptions.CREDENTIALS_FIXED_ACCESS_EXPIRATION_EPOCH_MILLIS);
+        options.add(PubSubOptions.MAX_IN_FLIGHT_REQUESTS);
+        options.add(CREDENTIALS_PROVIDER);
+        options.add(PubSubOptions.FAIL_ON_ERROR);
+        options.add(PubSubOptions.BATCHING_ENABLED);
+        options.add(PubSubOptions.BATCHING_ELEMENT_COUNT_THRESHOLD);
+        options.add(PubSubOptions.BATCHING_DELAY_THRESHOLD_MS);
+        options.add(PubSubOptions.BATCHING_REQUEST_BYTE_THRESHOLD);
+        options.add(PubSubOptions.BATCHING_MAX_OUTSTANDING_ELEMENT_COUNT);
+        options.add(PubSubOptions.BATCHING_MAX_OUTSTANDING_REQUEST_BYTES);
+        options.add(PubSubOptions.RETRY_SETTINGS_INITIAL_DELAY_MS);
+        options.add(PubSubOptions.RETRY_SETTINGS_MAX_ATTEMPTS);
+        options.add(PubSubOptions.RETRY_SETTINGS_MAX_DELAY_MS);
+        options.add(PubSubOptions.COMPRESSION_ENABLED);
+        return options;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> forwardOptions() {
+        final Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(PubSubOptions.MAX_IN_FLIGHT_REQUESTS);
+        options.add(PubSubOptions.FAIL_ON_ERROR);
+        options.add(PubSubOptions.BATCHING_ENABLED);
+        options.add(PubSubOptions.BATCHING_ELEMENT_COUNT_THRESHOLD);
+        options.add(PubSubOptions.BATCHING_DELAY_THRESHOLD_MS);
+        options.add(PubSubOptions.BATCHING_REQUEST_BYTE_THRESHOLD);
+        options.add(PubSubOptions.BATCHING_MAX_OUTSTANDING_ELEMENT_COUNT);
+        options.add(PubSubOptions.BATCHING_MAX_OUTSTANDING_REQUEST_BYTES);
+        options.add(PubSubOptions.RETRY_SETTINGS_INITIAL_DELAY_MS);
+        options.add(PubSubOptions.RETRY_SETTINGS_MAX_ATTEMPTS);
+        options.add(PubSubOptions.RETRY_SETTINGS_MAX_DELAY_MS);
+        options.add(PubSubOptions.COMPRESSION_ENABLED);
+        return options;
+    }
+
+    private GcpPublisherConfig getResolvedPublisherConfig(ReadableConfig config) {
+        CredentialProviderFactory credentialProviderFactory = new CredentialProviderFactory();
+        CredentialProviderType credentialProviderType =
+                config.get(PubSubOptions.CREDENTIALS_PROVIDER_TYPE);
+        Map<String, String> credentialProviderOptions =
+                Optional.ofNullable(config.get(CREDENTIALS_PROVIDER))
+                        .orElse(Collections.emptyMap());
+
+        GcpPublisherConfig.Builder builder =
+                GcpPublisherConfig.builder()
+                        .setCredentialsProvider(
+                                credentialProviderFactory.createCredentialsProvider(
+                                        credentialProviderType, credentialProviderOptions));
+
+        Optional.ofNullable(getResolvedRetrySettings(config)).ifPresent(builder::setRetrySettings);
+        Optional.ofNullable(getResolvedBatchingSettings(config))
+                .ifPresent(builder::setBatchingSettings);
+        Optional.ofNullable(config.get(PubSubOptions.COMPRESSION_ENABLED))
+                .ifPresent(builder::setEnableCompression);
+        return builder.build();
+    }
+
+    private BatchingSettings getResolvedBatchingSettings(ReadableConfig config) {
+        BatchingSettings.Builder builder = BatchingSettings.newBuilder();
+        Optional<Long> batchCountThresholdOptional =
+                Optional.ofNullable(config.get(PubSubOptions.BATCHING_ELEMENT_COUNT_THRESHOLD));
+        Optional<Long> batchDelayThresholdOptional =
+                Optional.ofNullable(config.get(PubSubOptions.BATCHING_DELAY_THRESHOLD_MS));
+        Optional<Boolean> batchEnabledOptional =
+                Optional.ofNullable(config.get(PubSubOptions.BATCHING_ENABLED));
+        Optional<Long> batchRequestByteThresholdOptional =
+                Optional.ofNullable(config.get(PubSubOptions.BATCHING_REQUEST_BYTE_THRESHOLD));
+
+        Optional<Long> maxOutstandingElementCount =
+                Optional.ofNullable(
+                        config.get(PubSubOptions.BATCHING_MAX_OUTSTANDING_ELEMENT_COUNT));
+        Optional<Long> maxOutstandingRequestBytes =
+                Optional.ofNullable(
+                        config.get(PubSubOptions.BATCHING_MAX_OUTSTANDING_REQUEST_BYTES));
+
+        if (!batchCountThresholdOptional.isPresent()
+                && !batchDelayThresholdOptional.isPresent()
+                && (!batchEnabledOptional.isPresent() || !batchEnabledOptional.get())
+                && !batchRequestByteThresholdOptional.isPresent()
+                && !maxOutstandingElementCount.isPresent()
+                && !maxOutstandingRequestBytes.isPresent()) {
+
+            return null;
+        }
+
+        batchCountThresholdOptional.ifPresent(builder::setElementCountThreshold);
+        batchDelayThresholdOptional.ifPresent(
+                delay -> builder.setDelayThreshold(Duration.ofMillis(delay)));
+        batchEnabledOptional.ifPresent(builder::setIsEnabled);
+        batchRequestByteThresholdOptional.ifPresent(builder::setRequestByteThreshold);
+        if (maxOutstandingElementCount.isPresent() || maxOutstandingRequestBytes.isPresent()) {
+            FlowControlSettings.Builder flowControlSettingsBuilder =
+                    FlowControlSettings.newBuilder();
+            maxOutstandingElementCount.ifPresent(
+                    flowControlSettingsBuilder::setMaxOutstandingElementCount);
+            maxOutstandingRequestBytes.ifPresent(
+                    flowControlSettingsBuilder::setMaxOutstandingRequestBytes);
+            builder.setFlowControlSettings(flowControlSettingsBuilder.build());
+        }
+
+        return builder.build();
+    }
+
+    private RetrySettings getResolvedRetrySettings(ReadableConfig config) {
+        Optional<Long> initialDelayOptional =
+                Optional.ofNullable(config.get(PubSubOptions.RETRY_SETTINGS_INITIAL_DELAY_MS));
+        Optional<Integer> maxAttemptsOptional =
+                Optional.ofNullable(config.get(PubSubOptions.RETRY_SETTINGS_MAX_ATTEMPTS));
+        Optional<Long> maxDelayOptional =
+                Optional.ofNullable(config.get(PubSubOptions.RETRY_SETTINGS_MAX_DELAY_MS));
+        if (!initialDelayOptional.isPresent()
+                && !maxAttemptsOptional.isPresent()
+                && !maxDelayOptional.isPresent()) {
+            return null;
+        }
+
+        RetrySettings.Builder builder = RetrySettings.newBuilder();
+        initialDelayOptional.ifPresent(
+                delay -> builder.setInitialRetryDelay(Duration.ofMillis(delay)));
+        maxAttemptsOptional.ifPresent(builder::setMaxAttempts);
+        maxDelayOptional.ifPresent(delay -> builder.setMaxRetryDelay(Duration.ofMillis(delay)));
+        return builder.build();
+    }
+}

--- a/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/connector/gcp/pubsub/table/PubSubOptions.java
+++ b/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/connector/gcp/pubsub/table/PubSubOptions.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.gcp.pubsub.table;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+
+import java.util.Map;
+
+/** Options for the Pub/Sub connector. */
+@PublicEvolving
+public class PubSubOptions {
+    public static final ConfigOption<String> TOPIC =
+            ConfigOptions.key("topic")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Name of the Pub/Sub topic backing this table.");
+
+    public static final ConfigOption<String> PROJECT =
+            ConfigOptions.key("project")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("GCP project ID.");
+
+    public static final ConfigOption<Integer> MAX_IN_FLIGHT_REQUESTS =
+            ConfigOptions.key("sink.inflight-requests.max")
+                    .intType()
+                    .noDefaultValue()
+                    .withDescription("Maximum number of inflight requests.");
+
+    public static final ConfigOption<Boolean> FAIL_ON_ERROR =
+            ConfigOptions.key("sink.fail-on-error")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Flag to trigger global failure on error.");
+
+    public static final ConfigOption<Boolean> BATCHING_ENABLED =
+            ConfigOptions.key("sink.batching.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Flag to enable batching.");
+
+    public static final ConfigOption<Long> BATCHING_ELEMENT_COUNT_THRESHOLD =
+            ConfigOptions.key("sink.batching.element-count-threshold")
+                    .longType()
+                    .noDefaultValue()
+                    .withDescription("Batching settings Element count threshold.");
+
+    public static final ConfigOption<Long> BATCHING_DELAY_THRESHOLD_MS =
+            ConfigOptions.key("sink.batching.delay-threshold-millis")
+                    .longType()
+                    .noDefaultValue()
+                    .withDescription("Batching settings delay threshold in milliseconds.");
+
+    public static final ConfigOption<Long> BATCHING_REQUEST_BYTE_THRESHOLD =
+            ConfigOptions.key("sink.batching.request-byte-threshold")
+                    .longType()
+                    .noDefaultValue()
+                    .withDescription("Batching settings request byte threshold.");
+
+    public static final ConfigOption<Long> BATCHING_MAX_OUTSTANDING_ELEMENT_COUNT =
+            ConfigOptions.key("sink.batching.max-outstanding-element-count")
+                    .longType()
+                    .noDefaultValue()
+                    .withDescription("Batching settings max outstanding element count.");
+
+    public static final ConfigOption<Long> BATCHING_MAX_OUTSTANDING_REQUEST_BYTES =
+            ConfigOptions.key("sink.batching.max-outstanding-request-bytes")
+                    .longType()
+                    .noDefaultValue()
+                    .withDescription("Batching settings max outstanding request bytes.");
+
+    public static final ConfigOption<Long> RETRY_SETTINGS_INITIAL_DELAY_MS =
+            ConfigOptions.key("sink.retry.initial-delay-millis")
+                    .longType()
+                    .noDefaultValue()
+                    .withDescription("Retry settings initial delay.");
+
+    public static final ConfigOption<Integer> RETRY_SETTINGS_MAX_ATTEMPTS =
+            ConfigOptions.key("sink.retry.max-attempts")
+                    .intType()
+                    .noDefaultValue()
+                    .withDescription("Retry settings maximum retry attempts.");
+
+    public static final ConfigOption<Long> RETRY_SETTINGS_MAX_DELAY_MS =
+            ConfigOptions.key("sink.retry.max-delay-millis")
+                    .longType()
+                    .noDefaultValue()
+                    .withDescription("Retry settings max delay.");
+
+    public static final ConfigOption<Map<String, String>> CREDENTIALS_PROVIDER =
+            ConfigOptions.key("credentials-provider")
+                    .mapType()
+                    .noDefaultValue()
+                    .withDescription("Credentials provider options.");
+
+    public static final ConfigOption<CredentialProviderType> CREDENTIALS_PROVIDER_TYPE =
+            ConfigOptions.key("credentials-provider.type")
+                    .enumType(CredentialProviderType.class)
+                    .defaultValue(CredentialProviderType.DEFAULT)
+                    .withDescription("Type of the GCP credentials provider.");
+
+    public static final ConfigOption<String> CREDENTIALS_FIXED_JSON =
+            ConfigOptions.key("credentials-provider.fixed.credentials-json")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Json formatted string of the GCP credentials for fixed credentials provider.");
+
+    public static final ConfigOption<String> CREDENTIALS_FIXED_ACCESS_TOKEN =
+            ConfigOptions.key("credentials-provider.fixed.credentials.access-token")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Access token of GCP credentials for fixed credentials provider.");
+
+    public static final ConfigOption<Long> CREDENTIALS_FIXED_ACCESS_EXPIRATION_EPOCH_MILLIS =
+            ConfigOptions.key(
+                            "credentials-provider.fixed.credentials.access-expiration-epoch-millis")
+                    .longType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Expiration time epoch in millis of GCP credentials for fixed credentials provider.");
+
+    public static final ConfigOption<Boolean> COMPRESSION_ENABLED =
+            ConfigOptions.key("sink.compression.enabled")
+                    .booleanType()
+                    .noDefaultValue()
+                    .withDescription("Flag to enable compression for the Pub/Sub messages.");
+
+    private PubSubOptions() {}
+}

--- a/flink-connector-gcp-pubsub/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/flink-connector-gcp-pubsub/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.connector.gcp.pubsub.table.PubSubDynamicSinkFactory

--- a/flink-connector-gcp-pubsub/src/test/java/org/apache/flink/connector/gcp/pubsub/table/CredentialProviderFactoryTest.java
+++ b/flink-connector-gcp-pubsub/src/test/java/org/apache/flink/connector/gcp/pubsub/table/CredentialProviderFactoryTest.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.gcp.pubsub.table;
+
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.api.gax.core.GoogleCredentialsProvider;
+import com.google.auth.Credentials;
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.GoogleCredentials;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.sql.Date;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+
+/** Tests for {@link CredentialProviderFactory}. */
+class CredentialProviderFactoryTest {
+
+    private static final String TEST_CLIENT_ID = "client-id";
+    private static final String TEST_JSON_CREDENTIALS;
+
+    static {
+        try {
+            // Generate a private key for testing
+            KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+            keyPairGenerator.initialize(2048); // Key size
+            KeyPair keyPair = keyPairGenerator.generateKeyPair();
+            PrivateKey privateKey = keyPair.getPrivate();
+            PKCS8EncodedKeySpec pkcs8EncodedKeySpec =
+                    new PKCS8EncodedKeySpec(privateKey.getEncoded());
+            PrivateKey key = KeyFactory.getInstance("RSA").generatePrivate(pkcs8EncodedKeySpec);
+            // private key
+            String testPkcs8PrivateKey =
+                    "-----BEGIN PRIVATE KEY-----\n"
+                            + Base64.getEncoder().encodeToString(key.getEncoded()) // private key
+                            + "\n-----END PRIVATE KEY-----";
+            TEST_JSON_CREDENTIALS =
+                    "{\"type\": \"service_account\", "
+                            + "\"project_id\": \"project-id\","
+                            + " \"private_key_id\": \"1234567890abcdef1234567890abcdef12345678\", "
+                            + "\"private_key\": \""
+                            + testPkcs8PrivateKey
+                            + "\", \"client_email\": \"\", \"client_id\": \""
+                            + TEST_CLIENT_ID
+                            + "\", "
+                            + "\"auth_uri\": \"https://accounts.google.com/o/oauth2/auth\","
+                            + " \"token_uri\": \"https://oauth2.googleapis.com/token\", "
+                            + "\"auth_provider_x509_cert_url\": \"auth-provider-x509-cert-url\", "
+                            + "\"client_x509_cert_url\": \"client-x509-cert-url\"}";
+        } catch (InvalidKeySpecException | NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void createDefaultCredentialsProvider() {
+        CredentialProviderFactory factory = new CredentialProviderFactory();
+        CredentialsProvider credentialsProvider =
+                factory.createCredentialsProvider(CredentialProviderType.DEFAULT, null);
+        assertThat(credentialsProvider).isNotNull();
+        assertThat(credentialsProvider).isInstanceOf(GoogleCredentialsProvider.class);
+    }
+
+    @Test
+    void createGoogleCredentialsProvider() {
+        CredentialProviderFactory factory = new CredentialProviderFactory();
+        CredentialsProvider credentialsProvider =
+                factory.createCredentialsProvider(CredentialProviderType.GOOGLE_CREDENTIALS, null);
+        assertThat(credentialsProvider).isNotNull();
+        assertThat(credentialsProvider).isInstanceOf(GoogleCredentialsProvider.class);
+    }
+
+    @Test
+    void createFixedCredentialsProviderFailsIfOptionsAreNull() {
+        CredentialProviderFactory factory = new CredentialProviderFactory();
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(
+                        () -> factory.createCredentialsProvider(CredentialProviderType.FIXED, null))
+                .withMessage(
+                        "Fixed credential provider requires 'credentials-provider.fixed.credentials-json' or 'credentials-provider.fixed.credentials.access-token' options to be set");
+    }
+
+    @Test
+    void createFixedCredentialsProviderFailsIfNoOptionsAreProvided() {
+        CredentialProviderFactory factory = new CredentialProviderFactory();
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(
+                        () ->
+                                factory.createCredentialsProvider(
+                                        CredentialProviderType.FIXED, Collections.emptyMap()))
+                .withMessage(
+                        "Fixed credential provider requires 'credentials-provider.fixed.credentials-json' or 'credentials-provider.fixed.credentials.access-token' options to be set");
+    }
+
+    @Test
+    void createFixedCredentialsProviderFailsIfAccessTokenIsEmpty() {
+        CredentialProviderFactory factory = new CredentialProviderFactory();
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(
+                        () ->
+                                factory.createCredentialsProvider(
+                                        CredentialProviderType.FIXED,
+                                        Collections.singletonMap(
+                                                "fixed.credentials.access-token", "")))
+                .withMessage(
+                        "Fixed credential provider requires 'credentials-provider.fixed.credentials-json' or 'credentials-provider.fixed.credentials.access-token' options to be set");
+    }
+
+    @Test
+    void createFixedCredentialsProviderPassesIfOnlyAccessTokenIsProvided() {
+        CredentialProviderFactory factory = new CredentialProviderFactory();
+        CredentialsProvider credentialsProvider =
+                factory.createCredentialsProvider(
+                        CredentialProviderType.FIXED,
+                        Collections.singletonMap("fixed.credentials.access-token", "access-token"));
+        assertThat(credentialsProvider).isNotNull();
+        assertThat(credentialsProvider).isInstanceOf(FixedCredentialsProvider.class);
+    }
+
+    @Test
+    void createFixedCredentialsProviderFailsIfOnlyExpirationEpochMillisIsProvided() {
+        CredentialProviderFactory factory = new CredentialProviderFactory();
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(
+                        () ->
+                                factory.createCredentialsProvider(
+                                        CredentialProviderType.FIXED,
+                                        Collections.singletonMap(
+                                                "fixed.credentials.access-expiration-epoch-millis",
+                                                "123")))
+                .withMessage(
+                        "Fixed credential provider requires 'credentials-provider.fixed.credentials-json' or 'credentials-provider.fixed.credentials.access-token' options to be set");
+    }
+
+    @Test
+    void createFixedCredentialsWithJsonCredentials() throws IOException {
+        CredentialProviderFactory factory = new CredentialProviderFactory();
+        CredentialsProvider credentialsProvider =
+                factory.createCredentialsProvider(
+                        CredentialProviderType.FIXED,
+                        Collections.singletonMap("fixed.credentials-json", TEST_JSON_CREDENTIALS));
+
+        assertThat(credentialsProvider).isNotNull();
+        assertThat(credentialsProvider).isInstanceOf(FixedCredentialsProvider.class);
+
+        Credentials credentials = ((FixedCredentialsProvider) credentialsProvider).getCredentials();
+        assertThat(credentials).isNotNull();
+        assertThat(credentials)
+                .isEqualTo(
+                        GoogleCredentials.fromStream(
+                                new java.io.ByteArrayInputStream(
+                                        TEST_JSON_CREDENTIALS.getBytes())));
+    }
+
+    @Test
+    void createFixedCredentialsWithAccessToken() {
+        CredentialProviderFactory factory = new CredentialProviderFactory();
+        Map<String, String> options = new HashMap<>();
+        options.put("fixed.credentials.access-token", "access-token");
+        options.put("fixed.credentials.access-expiration-epoch-millis", "123");
+        CredentialsProvider credentialsProvider =
+                factory.createCredentialsProvider(CredentialProviderType.FIXED, options);
+
+        assertThat(credentialsProvider).isNotNull();
+        assertThat(credentialsProvider).isInstanceOf(FixedCredentialsProvider.class);
+
+        Credentials credentials = ((FixedCredentialsProvider) credentialsProvider).getCredentials();
+        assertThat(credentials).isNotNull();
+        assertThat(credentials)
+                .isEqualTo(
+                        GoogleCredentials.create(
+                                new AccessToken(
+                                        "access-token",
+                                        Date.from(java.time.Instant.ofEpochMilli(123)))));
+    }
+}

--- a/flink-connector-gcp-pubsub/src/test/java/org/apache/flink/connector/gcp/pubsub/table/PubSubDynamicSinkFactoryTest.java
+++ b/flink-connector-gcp-pubsub/src/test/java/org/apache/flink/connector/gcp/pubsub/table/PubSubDynamicSinkFactoryTest.java
@@ -1,0 +1,293 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.gcp.pubsub.table;
+
+import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.connector.gcp.pubsub.sink.PubSubSinkV2;
+import org.apache.flink.connector.gcp.pubsub.sink.config.GcpPublisherConfig;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.sink.SinkV2Provider;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.factories.TableOptionsBuilder;
+import org.apache.flink.table.factories.TestFormatFactory;
+import org.apache.flink.table.runtime.connector.sink.SinkRuntimeProviderContext;
+import org.apache.flink.table.types.DataType;
+
+import com.google.api.gax.batching.BatchingSettings;
+import com.google.api.gax.batching.FlowControlSettings;
+import com.google.api.gax.retrying.RetrySettings;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.threeten.bp.Duration;
+
+import java.util.Map;
+
+import static com.google.cloud.pubsub.v1.SubscriptionAdminSettings.defaultCredentialsProviderBuilder;
+import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSink;
+
+/** Tests for {@link org.apache.flink.connector.gcp.pubsub.table.PubSubDynamicSinkFactory}. */
+class PubSubDynamicSinkFactoryTest {
+    private static final String PROJECT = "test-project";
+    private static final String TOPIC = "test-topic";
+
+    @Test
+    void goodTableSinkDefaultTableConfig() {
+        ResolvedSchema sinkSchema = defaultSinkSchema();
+        DataType physicalDataType = sinkSchema.toPhysicalRowDataType();
+        Map<String, String> sinkOptions = defaultTableOptions().build();
+
+        // Construct actual DynamicTableSink using FactoryUtil
+        PubSubDynamicSink actualSink = (PubSubDynamicSink) createTableSink(sinkSchema, sinkOptions);
+
+        // Construct expected DynamicTableSink using factory under test
+        PubSubDynamicSink expectedSink = constructExpectedSink(physicalDataType, null, false);
+
+        assertTableSinkEqualsAndOfCorrectType(actualSink, expectedSink);
+    }
+
+    @Test
+    void tableSinkWithMaxInflightOverride() {
+        ResolvedSchema sinkSchema = defaultSinkSchema();
+        DataType physicalDataType = sinkSchema.toPhysicalRowDataType();
+        Map<String, String> sinkOptions =
+                defaultTableOptions().withTableOption("sink.inflight-requests.max", "10").build();
+
+        // Construct actual DynamicTableSink using FactoryUtil
+        PubSubDynamicSink actualSink = (PubSubDynamicSink) createTableSink(sinkSchema, sinkOptions);
+        // Construct expected DynamicTableSink using factory under test
+        PubSubDynamicSink expectedSink = constructExpectedSink(physicalDataType, 10, false);
+        assertTableSinkEqualsAndOfCorrectType(actualSink, expectedSink);
+    }
+
+    @Test
+    void tableSinkWithFailOnError() {
+        ResolvedSchema sinkSchema = defaultSinkSchema();
+        DataType physicalDataType = sinkSchema.toPhysicalRowDataType();
+        Map<String, String> sinkOptions =
+                defaultTableOptions().withTableOption("sink.fail-on-error", "true").build();
+
+        // Construct actual DynamicTableSink using FactoryUtil
+        PubSubDynamicSink actualSink = (PubSubDynamicSink) createTableSink(sinkSchema, sinkOptions);
+        // Construct expected DynamicTableSink using factory under test
+        PubSubDynamicSink expectedSink = constructExpectedSink(physicalDataType, null, true);
+        assertTableSinkEqualsAndOfCorrectType(actualSink, expectedSink);
+    }
+
+    @Test
+    void tableSinkWithFixedCredentialProviderFailsIfCredentialsFileNotProvided() {
+        ResolvedSchema sinkSchema = defaultSinkSchema();
+        Map<String, String> sinkOptions =
+                defaultTableOptions().withTableOption("credentials-provider.type", "fixed").build();
+
+        // Construct actual DynamicTableSink using FactoryUtil
+        Assertions.assertThatThrownBy(() -> createTableSink(sinkSchema, sinkOptions))
+                .cause()
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Fixed credential provider requires 'credentials-provider.fixed.credentials-json' or 'credentials-provider.fixed.credentials.access-token' options to be set");
+    }
+
+    @Test
+    void tableSinkWithGoogleCredentialsSucceeds() {
+        ResolvedSchema sinkSchema = defaultSinkSchema();
+        DataType physicalDataType = sinkSchema.toPhysicalRowDataType();
+        Map<String, String> sinkOptions =
+                defaultTableOptions()
+                        .withTableOption("credentials-provider.type", "google-credentials")
+                        .build();
+
+        // Construct actual DynamicTableSink using FactoryUtil
+        PubSubDynamicSink actualSink = (PubSubDynamicSink) createTableSink(sinkSchema, sinkOptions);
+        // Construct expected DynamicTableSink using factory under test
+        PubSubDynamicSink expectedSink = constructExpectedSink(physicalDataType, null, false);
+        assertTableSinkEqualsAndOfCorrectType(actualSink, expectedSink);
+    }
+
+    @Test
+    void tableSinkWithBadCredentialProviderType() {
+        ResolvedSchema sinkSchema = defaultSinkSchema();
+        Map<String, String> sinkOptions =
+                defaultTableOptions().withTableOption("credentials-provider.type", "bad").build();
+
+        // Construct actual DynamicTableSink using FactoryUtil
+        Assertions.assertThatThrownBy(() -> createTableSink(sinkSchema, sinkOptions))
+                .cause()
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("Invalid value for option 'credentials-provider.type'");
+    }
+
+    @Test
+    void tableSinkWithBatchSettingsEnabled() {
+        ResolvedSchema sinkSchema = defaultSinkSchema();
+        DataType physicalDataType = sinkSchema.toPhysicalRowDataType();
+        Map<String, String> sinkOptions =
+                defaultTableOptions()
+                        .withTableOption("sink.batching.enabled", "true")
+                        .withTableOption("sink.batching.element-count-threshold", "100")
+                        .withTableOption("sink.batching.request-byte-threshold", "1000")
+                        .withTableOption("sink.batching.delay-threshold-millis", "1000")
+                        .withTableOption("sink.batching.max-outstanding-element-count", "1000")
+                        .withTableOption("sink.batching.max-outstanding-request-bytes", "10000")
+                        .build();
+
+        // Construct actual DynamicTableSink using FactoryUtil
+        PubSubDynamicSink actualSink = (PubSubDynamicSink) createTableSink(sinkSchema, sinkOptions);
+
+        // Construct expected DynamicTableSink using factory under test
+        PubSubDynamicSink expectedSink =
+                constructExpectedSink(
+                        physicalDataType,
+                        GcpPublisherConfig.builder()
+                                .setCredentialsProvider(defaultCredentialsProviderBuilder().build())
+                                .setBatchingSettings(
+                                        BatchingSettings.newBuilder()
+                                                .setDelayThreshold(Duration.ofMillis(1000))
+                                                .setElementCountThreshold(100L)
+                                                .setRequestByteThreshold(1000L)
+                                                .setFlowControlSettings(
+                                                        FlowControlSettings.newBuilder()
+                                                                .setMaxOutstandingElementCount(
+                                                                        1000L)
+                                                                .setMaxOutstandingRequestBytes(
+                                                                        10000L)
+                                                                .build())
+                                                .setIsEnabled(true)
+                                                .build())
+                                .build(),
+                        null,
+                        false);
+
+        assertTableSinkEqualsAndOfCorrectType(actualSink, expectedSink);
+    }
+
+    @Test
+    void tableSinkWithRetrySettings() {
+        ResolvedSchema sinkSchema = defaultSinkSchema();
+        DataType physicalDataType = sinkSchema.toPhysicalRowDataType();
+        Map<String, String> sinkOptions =
+                defaultTableOptions()
+                        .withTableOption("sink.retry.initial-delay-millis", "1000")
+                        .withTableOption("sink.retry.max-attempts", "10")
+                        .withTableOption("sink.retry.max-delay-millis", "10000")
+                        .build();
+
+        // Construct actual DynamicTableSink using FactoryUtil
+        PubSubDynamicSink actualSink = (PubSubDynamicSink) createTableSink(sinkSchema, sinkOptions);
+
+        // Construct expected DynamicTableSink using factory under test
+        PubSubDynamicSink expectedSink =
+                constructExpectedSink(
+                        physicalDataType,
+                        GcpPublisherConfig.builder()
+                                .setCredentialsProvider(defaultCredentialsProviderBuilder().build())
+                                .setRetrySettings(
+                                        RetrySettings.newBuilder()
+                                                .setInitialRetryDelay(Duration.ofMillis(1000))
+                                                .setMaxAttempts(10)
+                                                .setMaxRetryDelay(Duration.ofMillis(10000))
+                                                .build())
+                                .build(),
+                        null,
+                        false);
+        assertTableSinkEqualsAndOfCorrectType(actualSink, expectedSink);
+    }
+
+    @Test
+    void tableSinkWithCompressionEnabled() {
+        ResolvedSchema sinkSchema = defaultSinkSchema();
+        DataType physicalDataType = sinkSchema.toPhysicalRowDataType();
+        Map<String, String> sinkOptions =
+                defaultTableOptions().withTableOption("sink.compression.enabled", "true").build();
+
+        // Construct actual DynamicTableSink using FactoryUtil
+        PubSubDynamicSink actualSink = (PubSubDynamicSink) createTableSink(sinkSchema, sinkOptions);
+
+        // Construct expected DynamicTableSink using factory under test
+        PubSubDynamicSink expectedSink =
+                constructExpectedSink(
+                        physicalDataType,
+                        GcpPublisherConfig.builder()
+                                .setCredentialsProvider(defaultCredentialsProviderBuilder().build())
+                                .setEnableCompression(true)
+                                .build(),
+                        null,
+                        false);
+        assertTableSinkEqualsAndOfCorrectType(actualSink, expectedSink);
+    }
+
+    private ResolvedSchema defaultSinkSchema() {
+        return ResolvedSchema.of(
+                Column.physical("name", DataTypes.STRING()),
+                Column.physical("curr_id", DataTypes.BIGINT()),
+                Column.physical("time", DataTypes.TIMESTAMP(3)));
+    }
+
+    private TableOptionsBuilder defaultTableOptions() {
+        String connector = PubSubDynamicSinkFactory.IDENTIFIER;
+        String format = TestFormatFactory.IDENTIFIER;
+        return new TableOptionsBuilder(connector, format)
+                // default table options
+                .withTableOption("project", PROJECT)
+                .withTableOption("topic", TOPIC)
+                .withFormatOption(TestFormatFactory.DELIMITER, ",")
+                .withFormatOption(TestFormatFactory.FAIL_ON_MISSING, "true");
+    }
+
+    private PubSubDynamicSink constructExpectedSink(
+            DataType physicalDataType, Integer maxInflightRequests, boolean failOnError) {
+        return constructExpectedSink(
+                physicalDataType,
+                GcpPublisherConfig.builder()
+                        .setCredentialsProvider(defaultCredentialsProviderBuilder().build())
+                        .build(),
+                maxInflightRequests,
+                failOnError);
+    }
+
+    private PubSubDynamicSink constructExpectedSink(
+            DataType physicalDataType,
+            GcpPublisherConfig gcpPublisherConfig,
+            Integer maxInflightRequests,
+            boolean failOnError) {
+        return new PubSubDynamicSink(
+                physicalDataType,
+                PROJECT,
+                TOPIC,
+                gcpPublisherConfig,
+                new TestFormatFactory.EncodingFormatMock(","),
+                maxInflightRequests,
+                failOnError);
+    }
+
+    private void assertTableSinkEqualsAndOfCorrectType(
+            DynamicTableSink actualSink, DynamicTableSink expectedSink) {
+        // verify that the constructed DynamicTableSink is as expected
+        Assertions.assertThat(actualSink).isEqualTo(expectedSink);
+
+        // verify the produced sink
+        DynamicTableSink.SinkRuntimeProvider sinkFunctionProvider =
+                actualSink.getSinkRuntimeProvider(new SinkRuntimeProviderContext(false));
+        Sink<RowData> sinkFunction = ((SinkV2Provider) sinkFunctionProvider).createSink();
+        Assertions.assertThat(sinkFunction).isInstanceOf(PubSubSinkV2.class);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -342,6 +342,13 @@ under the License.
 				<version>2.6</version>
 			</dependency>
 
+			<!-- For dependency convergence -->
+			<dependency>
+				<groupId>commons-codec</groupId>
+				<artifactId>commons-codec</artifactId>
+				<version>1.16.1</version>
+			</dependency>
+
 			<dependency>
 				<!-- This is the way we get a consistent set of versions of the Google tools -->
 				<groupId>com.google.cloud</groupId>


### PR DESCRIPTION
## Description
- Add Table Api support for PubSubSinkV2 [FLINK-36077]
- Added credential providers options for Json Credentials and Access token credentials
## Testing
- Added Unit tests
- Tested against GCP pubsub
## Documentation
- https://issues.apache.org/jira/browse/FLINK-36078