### PR TITLE
[FLINK-36616] fix npe in GcpPublisherConfig

### DIFF
--- a/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/connector/gcp/pubsub/sink/config/GcpPublisherConfig.java
+++ b/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/connector/gcp/pubsub/sink/config/GcpPublisherConfig.java
@@ -56,7 +56,6 @@ public class GcpPublisherConfig implements Serializable {
             return null;
         }
         return transportChannelProvider.getTransportChannelProvider();
-
     }
 
     public Boolean getEnableCompression() {

--- a/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/connector/gcp/pubsub/sink/config/GcpPublisherConfig.java
+++ b/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/connector/gcp/pubsub/sink/config/GcpPublisherConfig.java
@@ -52,7 +52,11 @@ public class GcpPublisherConfig implements Serializable {
     }
 
     public TransportChannelProvider getTransportChannelProvider() {
-        return transportChannelProvider.getTransportChannelProvider();
+        if (transportChannelProvider==null){
+            return null;
+        } else{
+            return transportChannelProvider.getTransportChannelProvider();
+        }
     }
 
     public Boolean getEnableCompression() {

--- a/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/connector/gcp/pubsub/sink/config/GcpPublisherConfig.java
+++ b/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/connector/gcp/pubsub/sink/config/GcpPublisherConfig.java
@@ -52,11 +52,11 @@ public class GcpPublisherConfig implements Serializable {
     }
 
     public TransportChannelProvider getTransportChannelProvider() {
-        if (transportChannelProvider==null){
+        if (transportChannelProvider == null) {
             return null;
-        } else{
-            return transportChannelProvider.getTransportChannelProvider();
         }
+        return transportChannelProvider.getTransportChannelProvider();
+
     }
 
     public Boolean getEnableCompression() {

--- a/flink-connector-gcp-pubsub/src/test/java/org/apache/flink/connector/gcp/pubsub/sink/PubSubSinkV2BuilderTest.java
+++ b/flink-connector-gcp-pubsub/src/test/java/org/apache/flink/connector/gcp/pubsub/sink/PubSubSinkV2BuilderTest.java
@@ -81,6 +81,19 @@ class PubSubSinkV2BuilderTest {
     }
 
     @Test
+    void gcpPublisherConfigReturnsNullTransportChannel() {
+        PubSubSinkV2Builder<String> builder = new PubSubSinkV2Builder<>();
+        SerializationSchema<String> serializationSchema = new SimpleStringSchema();
+        GcpPublisherConfig gcpPublisherConfig =
+                GcpPublisherConfig.builder()
+                        .setCredentialsProvider(NoCredentialsProvider.create())
+                        .build();
+
+
+        assertThat(gcpPublisherConfig).hasFieldOrPropertyWithValue("transportChannelProvider", null);
+    }
+
+    @Test
     void builderThrowsNullPointerExceptionOnNullTopicId() {
         PubSubSinkV2Builder<String> builder = PubSubSinkV2.<String>builder();
         SerializationSchema<String> serializationSchema = new SimpleStringSchema();

--- a/flink-connector-gcp-pubsub/src/test/java/org/apache/flink/connector/gcp/pubsub/sink/PubSubSinkV2BuilderTest.java
+++ b/flink-connector-gcp-pubsub/src/test/java/org/apache/flink/connector/gcp/pubsub/sink/PubSubSinkV2BuilderTest.java
@@ -89,7 +89,8 @@ class PubSubSinkV2BuilderTest {
                         .setCredentialsProvider(NoCredentialsProvider.create())
                         .build();
 
-        assertThat(gcpPublisherConfig).hasFieldOrPropertyWithValue("transportChannelProvider", null);
+        assertThat(gcpPublisherConfig)
+                .hasFieldOrPropertyWithValue("transportChannelProvider", null);
     }
 
     @Test

--- a/flink-connector-gcp-pubsub/src/test/java/org/apache/flink/connector/gcp/pubsub/sink/PubSubSinkV2BuilderTest.java
+++ b/flink-connector-gcp-pubsub/src/test/java/org/apache/flink/connector/gcp/pubsub/sink/PubSubSinkV2BuilderTest.java
@@ -89,7 +89,6 @@ class PubSubSinkV2BuilderTest {
                         .setCredentialsProvider(NoCredentialsProvider.create())
                         .build();
 
-
         assertThat(gcpPublisherConfig).hasFieldOrPropertyWithValue("transportChannelProvider", null);
     }
 


### PR DESCRIPTION
hey there, 
with current implementation PubSubSinkV2 throws NPE due to transportChannelProvider being null. transportChannelProvider is mostly used for testing. 