### PR TITLE
[FLINK-36595][docs] Explicitly set connector compatibility as string …

### DIFF
--- a/docs/data/pubsub.yml
+++ b/docs/data/pubsub.yml
@@ -17,6 +17,6 @@
 ################################################################################
 
 version: 3.1.0
-flink_compatibility: [1.18, 1.19]
+flink_compatibility: ["1.18", "1.19"]
 variants:
   - maven: flink-connector-gcp-pubsub


### PR DESCRIPTION
…to prevent version comparison mismatch

## Purpose of the change

* Set version as string to prevent version comparison mismatch. Issue has happened for other connectors too : https://github.com/apache/flink-connector-kafka/pull/132






## Significant changes
*(Please check any boxes [x] if the answer is "yes". You can first publish the PR and check them afterwards, for convenience.)*
- [ ] Dependencies have been added or upgraded
- [ ] Public API has been changed (Public API is any class annotated with `@Public(Evolving)`)
- [ ] Serializers have been changed
- [ ] New feature has been introduced
  - If yes, how is this documented? (not applicable / docs / JavaDocs / not documented)